### PR TITLE
[fix] 게시글 생성 테스트 변경 #5

### DIFF
--- a/src/test/java/com/tea/web/community/post/application/service/PostServiceImplTest.java
+++ b/src/test/java/com/tea/web/community/post/application/service/PostServiceImplTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,10 +52,10 @@ class PostServiceImplTest {
                 .build();
 
         createRequestDto = PostCreateRequestDto.builder()
-                .type("NOTICE")
+                .type("BOARD")
                 .title("Test Title")
                 .content("Test Content")
-                .category(Category.NOTICE)
+                .category(Category.BOARD)
                 .thumbnailUrl("http://example.com/thumbnail.jpg")
                 .img1l("http://example.com/img1.jpg")
                 .img2l("http://example.com/img2.jpg")
@@ -74,15 +75,16 @@ class PostServiceImplTest {
         });
 
         // when
-        PostResponseDto response = postService.createPost(createRequestDto, userDetails);
+        postService.createPost(createRequestDto, userDetails);
 
         // then
-        assertThat(response).isNotNull();
-        assertThat(response.getTitle()).isEqualTo(createRequestDto.getTitle());
-        assertThat(response.getContent()).isEqualTo(createRequestDto.getContent());
-        assertThat(response.getType()).isEqualTo(createRequestDto.getType());
-        assertThat(response.getCategory()).isEqualTo(createRequestDto.getCategory());
-        assertThat(response.getThumbnailUrl()).isEqualTo(createRequestDto.getThumbnailUrl());
+        verify(postRepository).save(any(Post.class));
+        // assertThat(response).isNotNull();
+        // assertThat(response.getTitle()).isEqualTo(createRequestDto.getTitle());
+        // assertThat(response.getContent()).isEqualTo(createRequestDto.getContent());
+        // assertThat(response.getType()).isEqualTo(createRequestDto.getType());
+        // assertThat(response.getCategory()).isEqualTo(createRequestDto.getCategory());
+        // assertThat(response.getThumbnailUrl()).isEqualTo(createRequestDto.getThumbnailUrl());
     }
 
     @Test


### PR DESCRIPTION
- serviceImpl에서 반환값을 없앴으므로 입력값 비교 대신 레포지토리 save 메서드 확인

- 추가한 어드민 권한 만 NOTICE 게시글을 작성할 수 있으므로 에러가 있었음 -> BOARD 생성으로 해결