### PR TITLE
[fix] 게시글 작성 못하는 오류 수정 #5

### DIFF
--- a/src/main/java/com/tea/web/community/post/application/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/com/tea/web/community/post/application/dto/request/PostCreateRequestDto.java
@@ -15,8 +15,8 @@ public class PostCreateRequestDto {
     private String content;
     // private Category category;
     private String thumbnailUrl;
-    private String category;
-    private String subCategory;
+    private Long categoryId;
+    private Long subCategoryId;
     // private String img1l;
     // private String img2l;
     // private String img3l;

--- a/src/main/java/com/tea/web/community/post/application/service/PostServiceImpl.java
+++ b/src/main/java/com/tea/web/community/post/application/service/PostServiceImpl.java
@@ -61,9 +61,9 @@ public class PostServiceImpl implements PostService {
                 // throw new CustomException(ErrorType.ADMIN_ONLY_POST);
                 // }
                 // }
-                Category category = categoryRepository.findByCategoryName(request.getCategory())
+                Category category = categoryRepository.findById(request.getCategoryId())
                                 .orElseThrow(() -> new CustomException(ErrorType.CATEGORY_NOT_FOUND));
-                SubCategory subCategory = subCategoryRepository.findBySubCategoryName(request.getSubCategory())
+                SubCategory subCategory = subCategoryRepository.findById(request.getSubCategoryId())
                                 .orElseThrow(() -> new CustomException(ErrorType.CATEGORY_NOT_FOUND));
 
                 Post post = Post.builder()


### PR DESCRIPTION
- 원인: Request로 카테고리와 서브 카테고리의 이름을 받아옴
- 동일한 이름의 카테고리가 있을 경우 스프링에서 어떤 카테고리에 게시글을 생성해야할 지 모르게 됨.
- 수정사항: 카테고리, 서브카테고리의 id값을 받아오도록 수정정